### PR TITLE
Implement tracking graph

### DIFF
--- a/commands/compile.js
+++ b/commands/compile.js
@@ -98,7 +98,7 @@ module.exports.run = async (client, message, args, prefix, compilerAPI) => {
                 let file = '/var/www/html/discord-compiler/graph.py';
                 fs.stat(file, (err, stat) => {
                     if (err == null) {
-                        const process = spawn('python', file);
+                        const process = spawn('python', [file]);
                     }
                 });
 

--- a/commands/compile.js
+++ b/commands/compile.js
@@ -2,6 +2,10 @@ const Discord = require('discord.js');
 const WandBox = require ('../WandBox.js');
 const stripAnsi = require('strip-ansi');
 
+// py
+const fs = require('fs');
+const spawn = require('child_process').spawn;
+
 function cleanControlChars(dirty) {
     return stripAnsi(dirty);
 }
@@ -88,6 +92,16 @@ module.exports.run = async (client, message, args, prefix, compilerAPI) => {
                 embed.addField('Program Output', `\`\`\`${json.program_message}\`\`\``);
             }
             message.channel.send(embed).then((msg) => {
+
+                /* On the deployed instance, we will track usage. This wont
+                 * have any effect if this file doesn't exist on your fs */
+                let file = '/var/www/html/discord-compiler/graph.py';
+                fs.stat(file, (err, stat) => {
+                    if (err == null) {
+                        const process = spawn('python', file);
+                    }
+                });
+
                 if (json.status == 0)
                     msg.react('✅');
                 else


### PR DESCRIPTION
In an effort to track this bot's usage, it'd be a good idea to track daily requests since launch date. This graph can be seen on http://headlinedev.xyz/discord-compiler.

This change doesn't affect any installation other than my own