### PR TITLE
Fix odd message truncation

### DIFF
--- a/commands/compile.js
+++ b/commands/compile.js
@@ -158,7 +158,7 @@ module.exports.run = async (client, message, args, prefix, compilerAPI) => {
                     json.program_message = json.program_message.substring(0, 1016);
                 }
                 json.program_message = cleanControlChars(json.program_message);
-                embed.addField('Program Output', `\`\`\`${json.program_message}\`\`\``);
+                embed.addField('Program Output', `\`\`\`\n${json.program_message}\`\`\``);
             }
             message.channel.send(embed).then((msg) => {
 


### PR DESCRIPTION
The number zero, in discord's imaginary world, is a valid language for syntax highlighting, although no highlights appear to exist for it (???). Thus, the following embed from the bot would fail to include the number zero.
``````
```0
1
```
``````

The code needed to replicate this issue is present below, but this change is also great due to the fact that previous outputs were technically able to activate the embed's syntax highlighting. The new `\n` makes this impossible.

The (now) working test case:
```cpp
#include <iostream>

int main () {
    std::cout << '0' << std::endl;
    std::cout << '1' << std::endl;
}
```