### PR TITLE
Rework statistics tracking methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,6 @@ We also depend on the following npm packages.
 - discord.js
 - strip-ansi
 - node-fetch
+- dblapi.js
 
 Once these are installed simply execute `node index.js`

--- a/WandBox.js
+++ b/WandBox.js
@@ -53,7 +53,6 @@ class Compilers {
     }
 
     isValidCompiler(compiler) {
-
         for (let i = 0; i < this.languages.length; i++) {
             for (let j = 0; j < this.compilerinfo[this.languages[i]].length; j++) {
                 if (compiler == this.compilerinfo[this.languages[i]][j])

--- a/commands/compile.js
+++ b/commands/compile.js
@@ -3,10 +3,6 @@ const WandBox = require ('../WandBox.js');
 const stripAnsi = require('strip-ansi');
 const botconfig = require('../settings.json');
 
-// py
-const fs = require('fs');
-const spawn = require('child_process').spawn;
-
 function cleanControlChars(dirty) {
     return stripAnsi(dirty);
 }
@@ -181,14 +177,6 @@ module.exports.run = async (client, message, args, prefix, compilerAPI) => {
             }
             message.channel.send(embed).then((msg) => {
 
-                /* On the deployed instance, we will track usage. This wont
-                 * have any effect if this file doesn't exist on your fs */
-                let file = '/var/www/html/discord-compiler/graph.py';
-                fs.stat(file, (err, stat) => {
-                    if (err == null) {
-                        const process = spawn('python', [file]);
-                    }
-                });
 
                 if (json.status == 0)
                     msg.react('✅');

--- a/commands/languages.js
+++ b/commands/languages.js
@@ -1,4 +1,3 @@
-const Discord = require('discord.js');
 const DiscordMessageMenu = require ('./../menus');
 
 module.exports.run = async (client, message, args, prefix, compilerAPI) => {

--- a/index.js
+++ b/index.js
@@ -1,16 +1,26 @@
-const botconfig = require('./settings.json');
+// npm requirements
 const Discord = require('discord.js');
-const WandBox = require ('./WandBox.js');
-const Statistics = require('./statistics.js');
+const client = new Discord.Client({disableEveryone: true});
 const fs = require('fs');
 
-const client = new Discord.Client({disableEveryone: true});
-const servers = new Statistics.Servers(0, client);
+// source imports
+const botconfig = require('./settings.json');
+const WandBox = require ('./WandBox.js');
+const Statistics = require('./statistics.js');
 
+// discordbots.org
+const dbllib = require('dblapi.js');
+let dbl = null;
+if (botconfig.dbltoken && botconfig.dbltoken.length > 0)
+    dbl = new dbllib(botconfig.dbltoken, client);
+
+// source import instantiations 
+const servers = new Statistics.Servers(0, client, dbl);
 const compilerAPI = new WandBox.Compilers(() => {
     console.log('compiler loading has completed!');
     compilerAPI.initialize();
 });
+
 
 // Add commands
 console.log('loading commands...');

--- a/statistics.js
+++ b/statistics.js
@@ -1,0 +1,106 @@
+const fs = require('fs');
+const spawn = require('child_process').spawn;
+
+/**
+ * Manages server count for when statistics tracking & status display.
+ * Functions like |updateSite| have no effect if the graph.py doesn't exist,
+ * which is only useful for the main public instance. These statistics help
+ * track the bot's growth along with any other information that we deem to be
+ * relevant.
+ */
+class Servers {
+    /**
+     * Creates an object which represents the server count tracking
+     * 
+     * @param {Number} count 
+     * @param {Discord.Client} client 
+     */
+    constructor(count, client) {
+        this.count = count;
+        this.client = client;
+    }
+
+    /**
+     * Sets the server count to a new value
+     * 
+     * Note: this does not contain a call to updateAll()
+     * 
+     * @param {Number} count 
+     */
+    setCount(count) {
+        this.count = count;
+    }
+
+    /**
+     * Gets the current server count
+     */
+    getCount() {
+        return this.count;
+    }
+
+    /**
+     * Updates the website stats with the supplied server count
+     * @param {Number} count 
+     */
+    updateSite(count) {
+        fs.stat('/var/www/html/discord-compiler/graph.py', (err) => {
+            if (err == null) {
+                spawn('python', [file, 'servers', String(count)]);
+            }
+        });
+    }
+
+    /**
+     * Updates the discord presence with the supplied server count
+     * @param {Number} count 
+     */
+    updateDiscord(count) {
+        this.client.user.setPresence({ game: { name: `in ${count} servers | ;help`}, status: 'online'})
+        .catch(console.log);
+    }
+
+    /**
+     * Updates both the website & the discord presence with latest count
+     */
+    updateAll() {
+        this.updateSite(this.count);
+        this.updateDiscord(this.count);
+    }   
+
+    /**
+     * Increments the server count & updates all
+     */
+    inc() {
+        this.count++;
+        this.updateAll();
+    }
+
+    /**
+     * Decrements the server count and updates all
+     */
+    dec() {
+        this.count++;
+        this.updateAll();
+    }
+}
+
+/**
+ * Simple singleton class which contains stats tracking to be done
+ * on a request-by-request basis.
+ */
+class Requests {
+    /**
+     * Increments the stats request count by one. Like before,
+     * this has no effect if run outside of the public bot environment.
+     */
+    static DoRequest() {
+        let file = '/var/www/html/discord-compiler/graph.py';
+        fs.stat(file, (err, stat) => {
+            if (err == null) {
+                spawn('python', [file]);
+            }
+        });
+    }
+}
+
+module.exports = {Servers, Requests};

--- a/statistics.js
+++ b/statistics.js
@@ -13,11 +13,13 @@ class Servers {
      * Creates an object which represents the server count tracking
      * 
      * @param {Number} count 
-     * @param {Discord.Client} client 
+     * @param {Discord.Client} client
+     * @param {dbl} dbl 
      */
-    constructor(count, client) {
+    constructor(count, client, dbl) {
         this.count = count;
         this.client = client;
+        this.dbl = dbl;
     }
 
     /**
@@ -36,6 +38,16 @@ class Servers {
      */
     getCount() {
         return this.count;
+    }
+
+    /**
+     * Updates discordbots.org server count with the supplied value. Only functions on
+     * instance.
+     * @param {Number} count 
+     */
+    updateDBL(count) {
+        if (this.dbl)
+            this.dbl.postStats(count);
     }
 
     /**

--- a/statistics.js
+++ b/statistics.js
@@ -43,7 +43,8 @@ class Servers {
      * @param {Number} count 
      */
     updateSite(count) {
-        fs.stat('/var/www/html/discord-compiler/graph.py', (err) => {
+        let file = '/var/www/html/discord-compiler/graph.py';
+        fs.stat(file, (err) => {
             if (err == null) {
                 spawn('python', [file, 'servers', String(count)]);
             }
@@ -79,7 +80,7 @@ class Servers {
      * Decrements the server count and updates all
      */
     dec() {
-        this.count++;
+        this.count--;
         this.updateAll();
     }
 }


### PR DESCRIPTION
Before this change, statistics were tracked in a very hacked way. Code duplication was rampant, and it just wasn't very easy to read, nor was it efficient. I was sitting on these changes for a little while now and figured it's finally time to finish it up, so here we go.

Along with this rework, I've also added a new dependency which is `dblapi.js`. This was done in order to allow us to display our server count directly to our discordbots.org page. (yay!).