### PR TITLE
Implement Developer-only Commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-settings.json
+node_modules/
+*.json

--- a/commands/compile.js
+++ b/commands/compile.js
@@ -189,5 +189,6 @@ module.exports.run = async (client, message, args, prefix, compilerAPI) => {
 
 module.exports.help = {
     name:"compile",
-    description:"compiles given code"
+    description:"compiles given code",
+    dev: false
 }

--- a/commands/compilers.js
+++ b/commands/compilers.js
@@ -27,5 +27,6 @@ module.exports.run = async (client, message, args, prefix, compilerAPI) => {
 
 module.exports.help = {
     name:"compilers",
-    description:"displays all compilers"
+    description:"displays all compilers",
+    dev: false
 }

--- a/commands/help.js
+++ b/commands/help.js
@@ -5,7 +5,10 @@ module.exports.run = async (client, message, args, prefix) => {
     client.commands.forEach(element => {
         let name = element.help.name;
         let desc = element.help.description;
-        items.push('**' + prefix + name + '** - ' + desc + '\n');
+        let dev = element.help.dev;
+
+        if (!dev)
+            items.push('**' + prefix + name + '** - ' + desc + '\n');
     });
 
     let menu = new DiscordMessageMenu(message, 'Discord Compiler Bot Help Menu:', 0x00FF00, 6);
@@ -16,5 +19,6 @@ module.exports.run = async (client, message, args, prefix) => {
 
 module.exports.help = {
     name:"help",
-    description:"displays all commands"
+    description:"displays all commands",
+    dev: false
 }

--- a/commands/languages.js
+++ b/commands/languages.js
@@ -8,5 +8,6 @@ module.exports.run = async (client, message, args, prefix, compilerAPI) => {
 
 module.exports.help = {
     name:"languages",
-    description:"displays all supported languages"
+    description:"displays all supported languages",
+    dev: false
 }

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -10,5 +10,6 @@ module.exports.run = async (client, message, args, prefix) => {
 
 module.exports.help = {
     name:"ping",
-    description:"test command for the compiler bot"
+    description:"test command for the compiler bot",
+    dev: false
 }

--- a/commands/servers.js
+++ b/commands/servers.js
@@ -34,5 +34,6 @@ module.exports.run = async (client, message, args, prefix) => {
 
 module.exports.help = {
     name:"servers",
-    description:"displays all servers the bot is in"
+    description:"displays all servers the bot is in",
+    dev: true
 }

--- a/commands/servers.js
+++ b/commands/servers.js
@@ -1,0 +1,38 @@
+const DiscordMessageMenu = require ('./../menus');
+
+
+module.exports.run = async (client, message, args, prefix) => {
+
+    // populate local array
+    let guilds = [];
+    client.guilds.forEach(x => {
+        guilds.push([x.name, x.members.size]);
+    });
+
+    // sort local array by count (greatest to least)
+    guilds.sort((a, b) => {
+        if (a[1] == b[1])
+            return 0;
+
+        return (a[1] > b[1])? -1 : 1;
+    });
+
+    // add menu items
+    let items = [];
+    guilds.forEach(x => {
+        let count = x[1];
+        let name = x[0];
+        items.push('**' + name + '** - ' + count + ' users');
+    });
+    
+    // display menu
+    let menu = new DiscordMessageMenu(message, 'Discord Compiler Current Servers:', 0x00FF00, 15);
+    menu.setNumbered(false);
+    menu.buildMenu(items);
+    menu.displayPage(0);
+}
+
+module.exports.help = {
+    name:"servers",
+    description:"displays all servers the bot is in"
+}

--- a/index.js
+++ b/index.js
@@ -68,6 +68,10 @@ client.on('message', message => {
     let commandfile = client.commands.get(args[0]);
     if (commandfile) {
         Statistics.Requests.DoRequest();
+
+        if(commandfile.dev && message.author.id != botconfig.owner_id)
+            return;
+
         commandfile.run(client, message, args, botconfig.prefix, compilerAPI);
     }
 });

--- a/package.json
+++ b/package.json
@@ -21,5 +21,11 @@
   "bugs": {
     "url": "https://github.com/Headline/discord-compiler/issues"
   },
-  "homepage": "https://github.com/Headline/discord-compiler#readme"
+  "homepage": "https://github.com/Headline/discord-compiler#readme",
+  "dependencies": {
+    "dblapi.js": "^2.3.0",
+    "discord.js": "^11.4.2",
+    "node-fetch": "^2.3.0",
+    "strip-ansi": "^5.0.0"
+  }
 }


### PR DESCRIPTION
This is a great way (for me) to see what our most popular consumers are, and keep track of new large guilds. This pull request also implements the ability for other, new, commands to be created which are developer restricted. I considered making `!botinfo` restricted, but it contains no information that could be considered sensitive so it will remain public. 